### PR TITLE
Make rewrite-every-log-message remap logger names as well

### DIFF
--- a/common/src/main/java/dev/booky/stackdeobf/util/RemappingRewritePolicy.java
+++ b/common/src/main/java/dev/booky/stackdeobf/util/RemappingRewritePolicy.java
@@ -52,6 +52,8 @@ public final class RemappingRewritePolicy implements RewritePolicy {
 
         Log4jLogEvent.Builder builder = new Log4jLogEvent.Builder(source);
         if (this.rewriteMessages) {
+            builder.setLoggerName(this.mappings.remapString(source.getLoggerName()));
+
             String message = source.getMessage().getFormattedMessage();
             message = this.mappings.remapString(message);
             builder.setMessage(new SimpleMessage(message));


### PR DESCRIPTION
From the [description of `rewrite-every-log-message`](https://github.com/booky10/StackDeobfuscator/wiki/Configuration#rewrite-every-log-message-default-false):

> Toggles remapping every class mentioned anywhere in the log.

It seems quite counter-intuitive that logger names are not remapped, only the message contents are.

This PR simply adds this missing feature to the `rewrite-every-log-message` setting.

Before:
<img width="831" height="232" alt="before" src="https://github.com/user-attachments/assets/3ee00a44-bed2-431c-a143-2fe6cd0e308f" />

After:
<img width="831" height="232" alt="after" src="https://github.com/user-attachments/assets/9befd0d6-1d52-4c63-b95e-31d9edab4116" />
